### PR TITLE
Mark PR as approved by user, add two more filters and change layout

### DIFF
--- a/app/models/github/graphql_client.rb
+++ b/app/models/github/graphql_client.rb
@@ -34,8 +34,15 @@ module Github
                   repository {
                     nameWithOwner
                   }
-                  reviews {
-                    totalCount
+                  reviews(first: 100) {
+                    edges {
+                      node {
+                        author {
+                          login
+                        }
+                        state
+                      }
+                    }
                   }
                   reviewRequests(first: 100) {
                     edges {
@@ -69,7 +76,6 @@ module Github
 
       if data["data"]
         search_result = data["data"]["search"]
-        issue_count = search_result["issueCount"]
         edges = search_result["edges"]
 
         edges.map do |edge|

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,33 +1,43 @@
 # frozen_string_literal: true
 
 class PullRequest
-  attr_reader :author, :number, :title, :repository, :reviews, :reviewers, :created_at, :merged_at, :url
+  attr_reader :approvals, :author, :comments, :created_at, :is_draft, :merged_at, :number, :repository, :reviewers, :reviews, :title, :url
 
-  def initialize(author:, number:, title:, repository:, reviews:, reviewers:, created_at:, merged_at:, url:)
+  def initialize(approvals:, author:, comments:, created_at:, is_draft:, merged_at:, number:, repository:, reviewers:, reviews:, title:, url:)
+    @approvals = approvals
     @author = author
-    @number = number
-    @title = title
-    @repository = repository
-    @reviews = reviews
-    @reviewers = reviewers
+    @comments = comments
     @created_at = created_at
+    @is_draft = is_draft
     @merged_at = merged_at
+    @number = number
+    @repository = repository
+    @reviewers = reviewers
+    @reviews = reviews
+    @title = title
     @url = url
   end
 
   def self.from_graphql_node(node)
+    reviews = node["reviews"]["edges"].map { |review_edge| review_edge["node"]  }
+    approvals = reviews&.count { |review| review["state"] == "APPROVED" } || 0
+    comments = reviews&.count { |review| review["state"] == "COMMENTED" } || 0
+
     new(
+      approvals: approvals,
       author: node.dig("author", "login"),
+      comments: comments,
+      created_at: node["createdAt"],
+      is_draft: node["isDraft"],
+      merged_at: node["mergedAt"],
       number: node["number"],
-      title: node["title"],
       repository: node.dig("repository", "nameWithOwner"),
-      reviews: node.dig("reviews", "totalCount"),
       reviewers: node.dig("reviewRequests", "edges").map do |edge|
         edge.dig("node", "requestedReviewer", "login") ||
-          edge.dig("node", "requestedReviewer", "name")
+        edge.dig("node", "requestedReviewer", "name")
       end,
-      created_at: node["createdAt"],
-      merged_at: node["mergedAt"],
+      reviews: reviews.map { |review| { author: review["author"]["login"], state: review["state"] } },
+      title: node["title"],
       url: node["url"]
     )
   end

--- a/app/views/pr_groups/show.html.erb
+++ b/app/views/pr_groups/show.html.erb
@@ -48,8 +48,10 @@
           data-action="change->pull-requests#reloadList"
         >
           <option value="all" selected>All</option>
-          <option value="reviewed">Reviewed</option>
-          <option value="not-reviewed">Not Reviewed</option>
+          <option value="reviewed">I reviewed</option>
+          <option value="not-reviewed">I did not review</option>
+          <option value="approved">I approved</option>
+          <option value="not-approved">I did not approve</option>
         </select>
       </div>
 

--- a/spec/models/github/graphql_client_spec.rb
+++ b/spec/models/github/graphql_client_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Github::GraphqlClient do
                   title: "Test PR",
                   isDraft: false,
                   repository: { nameWithOwner: "my-org/repo" },
-                  reviews: { totalCount: 2 },
                   reviewRequests: {
                     edges: [
                       {
@@ -41,6 +40,34 @@ RSpec.describe Github::GraphqlClient do
                       }
                     ]
                   },
+                  reviews: {
+                    edges: [
+                      {
+                        node: {
+                          author: {
+                              login: "user1"
+                          },
+                          state: "DISMISSED"
+                        }
+                      },
+                      {
+                        node: {
+                          author: {
+                              login: "user1"
+                          },
+                          state: "APPROVED"
+                        }
+                      },
+                      {
+                        node: {
+                          author: {
+                              login: "user2"
+                          },
+                          state: "COMMENTED"
+                        }
+                      }
+                    ]
+                },
                   createdAt: "2023-01-01T00:00:00Z",
                   mergedAt: nil,
                   url: "https://github.com/my-org/repo/pull/1"


### PR DESCRIPTION
I am accomplishing a couple of things here:

* Refactor on pull requests controller to make code easier to read
* Fetch reviews for each PR on GitHub API
* Show when a PR is approved by the user
* Add two more filters: PRs the user approved and PRs the user did not approve
* Fix bug on reviewed PRs cleanup that was deleting PRs by mistake because the filters were removing Prs from the response
* Add  comments and approvals on the line of the PR