### PR TITLE
Manage drafts

### DIFF
--- a/app/javascript/controllers/pull_requests_controller.js
+++ b/app/javascript/controllers/pull_requests_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
     "filters",
     "header",
     "prList",
+    "prTypeFilter",
     "reviewFilter",
     "stateFilter",
     "title",
@@ -134,6 +135,10 @@ export default class extends Controller {
       if (this.hasStateFilterTarget && savedFilters.stateFilter) {
         this.stateFilterTarget.value = savedFilters.stateFilter;
       }
+
+      if (this.hasPrTypeFilterTarget && savedFilters.prTypeFilter) {
+        this.prTypeFilterTarget.value = savedFilters.prTypeFilter;
+      }
     }
   }
 
@@ -144,6 +149,8 @@ export default class extends Controller {
       reviewFilter: this.reviewFilterTarget.value,
 
       stateFilter: this.stateFilterTarget.value,
+
+      prTypeFilter: this.prTypeFilterTarget.value,
     };
 
     localStorage.setItem(`filters-${url.pathname}`, JSON.stringify(filters));
@@ -186,8 +193,11 @@ export default class extends Controller {
       );
 
       const bgColor = this.prItemBgColor(pr);
+      const draftClasses = `border-2 border-dashed border-slate-300 after:content-['Draft'] after:absolute after:top-1/2 after:right-20 after:-translate-y-1/2 after:text-3xl after:font-bold after:text-gray-200 after:pointer-events-none after:z-10`;
       const listItem = document.createElement("li");
-      listItem.className = `flex items-start gap-4 p-4 rounded-lg shadow-sm border border-gray-200 my-1 mr-2 relative ${bgColor}`;
+      listItem.className = `flex items-start gap-4 p-4 rounded-lg shadow-sm ${
+        pr.is_draft ? draftClasses : "border"
+      } border-gray-200 my-1 mr-2 relative ${bgColor}`;
 
       const checkbox = `<input type="checkbox" class="w-5 h-5 rounded focus:ring-2 focus:ring-indigo-300 accent-slate-900 ${
         isApproved ? "hidden" : ""
@@ -277,6 +287,7 @@ export default class extends Controller {
   applyFilters(pullRequests) {
     const reviewFilter = this.reviewFilterTarget.value;
     const stateFilter = this.stateFilterTarget.value;
+    const prTypeFilter = this.prTypeFilterTarget.value;
     const currentUser = localStorage.getItem("githubHandle") || "";
 
     return pullRequests.filter((pr) => {
@@ -295,7 +306,12 @@ export default class extends Controller {
         reviewFilter === "all" ||
         (reviewFilter === "my-review" && requiresMyReview);
 
-      return stateMatches && reviewMatches;
+      const prTypeMatches =
+        prTypeFilter === "all" ||
+        (prTypeFilter === "drafts" && pr.is_draft) ||
+        (prTypeFilter === "not-drafts" && !pr.is_draft);
+
+      return stateMatches && reviewMatches && prTypeMatches;
     });
   }
 

--- a/app/views/pr_groups/show.html.erb
+++ b/app/views/pr_groups/show.html.erb
@@ -57,7 +57,7 @@
 
       <!-- Filter by Reviewer -->
       <div class="w-full sm:w-1/2">
-        <label for="reviewer-filter" class="block text-sm font-medium text-gray-700 mb-1">Filter by My Review</label>
+        <label for="reviewer-filter" class="block text-sm font-medium text-gray-700 mb-1">Filter by review request</label>
         <select
           id="reviewer-filter"
           class="block w-full px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
@@ -65,7 +65,22 @@
           data-action="change->pull-requests#reloadList"
         >
           <option value="all" selected>All PRs</option>
-          <option value="my-review">Only PRs Requiring My Review</option>
+          <option value="my-review">Only PRs requiring my review</option>
+        </select>
+      </div>
+
+      <!-- Filter by Draft / Not Draft -->
+      <div class="w-full sm:w-1/3">
+        <label for="reviewer-filter" class="block text-sm font-medium text-gray-700 mb-1">Filter by type</label>
+        <select
+          id="reviewer-filter"
+          class="block w-full px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+          data-pull-requests-target="prTypeFilter"
+          data-action="change->pull-requests#reloadList"
+        >
+          <option value="all" selected>Pull requests and drafts</option>
+          <option value="not-drafts">Pull Requests</option>
+          <option value="drafts">Drafts</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
Prs can be drafts, but right now there is no visual clue that the PR is not ready for review yet. I am adding a visual change for drafts and creating a new filter to let users decide if they want to see only drafts, only full-fledged PRs, or all of them together.

![image](https://github.com/user-attachments/assets/4e7b9ef7-4864-40ea-9169-478410118c34)
